### PR TITLE
Broaden the public API of CocoaMQTT when built as a framework.

### DIFF
--- a/CocoaMQTT.xcodeproj/project.pbxproj
+++ b/CocoaMQTT.xcodeproj/project.pbxproj
@@ -187,7 +187,7 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = CocoaMQTT/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.ovenbits.CocoaMQTT;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -213,7 +213,7 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = CocoaMQTT/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.ovenbits.CocoaMQTT;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -313,6 +313,7 @@
 				8184EA2B1BD7D06200C5D9FB /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		8BF7033B198DDB7900A220F6 /* Build configuration list for PBXProject "CocoaMQTT" */ = {
 			isa = XCConfigurationList;

--- a/CocoaMQTT/CocoaMQTT.swift
+++ b/CocoaMQTT/CocoaMQTT.swift
@@ -89,7 +89,7 @@ public enum CocoaMQTTQOS: UInt8 {
 /**
  * Connection State
  */
-enum CocoaMQTTConnState: UInt8 {
+public enum CocoaMQTTConnState: UInt8 {
 
     case INIT = 0
 
@@ -170,7 +170,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient, GCDAsyncSocketDelegate, Cocoa
 
     //socket and connection
 
-    var connState = CocoaMQTTConnState.INIT
+    public var connState = CocoaMQTTConnState.INIT
 
     var socket: GCDAsyncSocket?
 
@@ -220,7 +220,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient, GCDAsyncSocketDelegate, Cocoa
         let msgId: UInt16 = _nextMessageId()
         let frame = CocoaMQTTFramePublish(msgid: msgId, topic: message.topic, payload: message.payload)
         frame.qos = message.qos.rawValue
-        frame.retain = message.retain
+        frame.retain = message.shouldRetain
         frame.dup = message.dup
         send(frame, tag: Int(msgId))
         if message.qos != CocoaMQTTQOS.QOS0 {

--- a/CocoaMQTT/CocoaMQTT.swift
+++ b/CocoaMQTT/CocoaMQTT.swift
@@ -220,7 +220,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient, GCDAsyncSocketDelegate, Cocoa
         let msgId: UInt16 = _nextMessageId()
         let frame = CocoaMQTTFramePublish(msgid: msgId, topic: message.topic, payload: message.payload)
         frame.qos = message.qos.rawValue
-        frame.retain = message.shouldRetain
+        frame.retain = message.retain
         frame.dup = message.dup
         send(frame, tag: Int(msgId))
         if message.qos != CocoaMQTTQOS.QOS0 {

--- a/CocoaMQTT/CocoaMQTTFrame.swift
+++ b/CocoaMQTT/CocoaMQTTFrame.swift
@@ -259,7 +259,7 @@ class CocoaMQTTFrameConnect: CocoaMQTTFrame {
         if let will = client.willMessage {
             flagWill = true
             flagWillQOS = will.qos.rawValue
-            flagWillRetain = will.retain
+            flagWillRetain = will.shouldRetain
             payload += will.topic.bytesWithLength
             payload += will.payload
         }

--- a/CocoaMQTT/CocoaMQTTFrame.swift
+++ b/CocoaMQTT/CocoaMQTTFrame.swift
@@ -259,7 +259,7 @@ class CocoaMQTTFrameConnect: CocoaMQTTFrame {
         if let will = client.willMessage {
             flagWill = true
             flagWillQOS = will.qos.rawValue
-            flagWillRetain = will.shouldRetain
+            flagWillRetain = will.retain
             payload += will.topic.bytesWithLength
             payload += will.payload
         }

--- a/CocoaMQTT/CocoaMQTTMessage.swift
+++ b/CocoaMQTT/CocoaMQTTMessage.swift
@@ -11,7 +11,7 @@ import Foundation
 /**
  * MQTT Message
  */
-public class CocoaMQTTMessage : NSObject {
+public class CocoaMQTTMessage {
 
     public var topic: String
 
@@ -26,7 +26,7 @@ public class CocoaMQTTMessage : NSObject {
 
     public var qos: CocoaMQTTQOS = .QOS1
 
-    public var shouldRetain: Bool = false
+    public var retain: Bool = false
 
     public var dup: Bool = false
 
@@ -40,7 +40,7 @@ public class CocoaMQTTMessage : NSObject {
         self.topic = topic
         self.payload = payload
         self.qos = qos
-        self.shouldRetain = retain
+        self.retain = retain
         self.dup = dup
     }
 

--- a/CocoaMQTT/CocoaMQTTMessage.swift
+++ b/CocoaMQTT/CocoaMQTTMessage.swift
@@ -11,7 +11,7 @@ import Foundation
 /**
  * MQTT Message
  */
-public class CocoaMQTTMessage {
+public class CocoaMQTTMessage : NSObject {
 
     public var topic: String
 
@@ -24,23 +24,23 @@ public class CocoaMQTTMessage {
         }
     }
 
-    var qos: CocoaMQTTQOS = .QOS1
+    public var qos: CocoaMQTTQOS = .QOS1
 
-    var retain: Bool = false
+    public var shouldRetain: Bool = false
 
-    var dup: Bool = false
+    public var dup: Bool = false
 
-    init(topic: String, string: String, qos: CocoaMQTTQOS = .QOS1) {
+    public init(topic: String, string: String, qos: CocoaMQTTQOS = .QOS1) {
         self.topic = topic
         self.payload = [UInt8](string.utf8)
         self.qos = qos
     }
 
-    init(topic: String, payload: [UInt8], qos: CocoaMQTTQOS = .QOS1, retain: Bool = false, dup: Bool = false) {
+    public init(topic: String, payload: [UInt8], qos: CocoaMQTTQOS = .QOS1, retain: Bool = false, dup: Bool = false) {
         self.topic = topic
         self.payload = payload
         self.qos = qos
-        self.retain = retain
+        self.shouldRetain = retain
         self.dup = dup
     }
 


### PR DESCRIPTION
- The deployment target is knocked back from 9.0 to 8.4.
- `connState`, and its associated enum `CocoaMQTTConnState` is made public. I decided to make it public instead of forcing the client to add code that makes assumptions (or leverages knowledge) about how CocoaMQTT operates internally to try to track the state of a connection.
- CocoaMQTTMessage is made public. This class is part of the message passing API, so it makes sense for it to be public.

@jlandon I'm wondering about the CocoaMQTTMessage being made an NSObject. It appears that in order to get a class into the framework header, it must derive from NSObject, so that's why I did it. But it has the side effect in this case of forcing us to change one of the properties. If this isn't necessary, I'd prefer to avoid it...but I do want the class visible in the framework header. What do you think? Is there a way to get a non-NSObject class into a framework header?
